### PR TITLE
Fix devtools dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "recharts": "^2.8.0",
     "react-query": "^3.39.3",
     "@tanstack/react-query": "^5.17.9",
-    "react-query-devtools": "^3.32.1"
+    "@tanstack/react-query-devtools": "^5.83.0"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- fix React Query devtools dependency

## Testing
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-unused-vars' was not found)*
- `npm run build` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888fc5ae00883269e50308d8ce2d3c1