### PR TITLE
Fix export line ending

### DIFF
--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -8,4 +8,4 @@ const connectionString = process.env.DATABASE_URL!
 const client = postgres(connectionString, { prepare: false })
 export const db = drizzle(client, { schema })
 
-export * from './schema' 
+export * from './schema'


### PR DESCRIPTION
## Summary
- remove stray whitespace and newline-terminate the last export

## Testing
- `npm run lint` *(fails: @typescript-eslint plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_688901c4c4f0832689d21e535adfcda2