### PR TITLE
Remove trailing shell prompt from env.example

### DIFF
--- a/env.example
+++ b/env.example
@@ -26,4 +26,4 @@ EMAIL_SERVER_PASSWORD=your_email_password_here
 EMAIL_FROM=noreply@aisocialmirror.com
 
 # Application Configuration
-NODE_ENV=development 
+NODE_ENV=development


### PR DESCRIPTION
## Summary
- trim stray shell prompt and add newline after `NODE_ENV` in `env.example`

## Testing
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-unused-vars' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_688901c234208326a0046ec68fa9234a